### PR TITLE
docs: fix authentication command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ npm run start
 ### 認証手順
 
 ```bash
-npm run setup  # または npm run auth
+npm run auth
 ```
 
 実行すると:


### PR DESCRIPTION
## Summary

READMEの認証手順に記載されていたコマンドを修正しました。

- `npm run setup` → `npm run auth`

`npm run setup`というスクリプトは存在せず、正しくは`npm run auth`です。

## Test plan

- [x] READMEの認証手順セクション(127-131行目)を確認
- [x] package.jsonに`npm run auth`スクリプトが存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)