### PR TITLE
feat: add getMeetings tool for retrieving calendar events on any date

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,11 @@ export default [
     rules: {
       ...typescript.configs.recommended.rules,
       '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unsafe-argument': 'error',
+      '@typescript-eslint/no-unsafe-assignment': 'error',
+      '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-unsafe-member-access': 'error',
+      '@typescript-eslint/no-unsafe-return': 'error',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-non-null-assertion': 'warn',

--- a/src/auth/token-manager.ts
+++ b/src/auth/token-manager.ts
@@ -37,7 +37,7 @@ export class TokenManager {
   async loadTokens(): Promise<TokenData | null> {
     try {
       const data = await fs.readFile(this.tokenPath, 'utf8');
-      return JSON.parse(data);
+      return JSON.parse(data) as TokenData;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  Tool,
+} from '@modelcontextprotocol/sdk/types.js';
 import {
   getTodayMeetingsTool,
   executeTodayMeetingsTool,
@@ -13,7 +17,7 @@ config();
 
 class GoogleCalendarMCPServer {
   private server: Server;
-  private tools: Map<string, any>;
+  private tools: Map<string, Tool>;
 
   constructor() {
     this.server = new Server(
@@ -54,14 +58,16 @@ class GoogleCalendarMCPServer {
       }
 
       if (name === 'getTodayMeetings') {
-        const result = await executeTodayMeetingsTool(args || {});
+        const result = await executeTodayMeetingsTool((args as Record<string, unknown>) || {});
         return {
           content: [result],
         };
       }
 
       if (name === 'getMeetings') {
-        const result = await executeMeetingsTool((args as any) || {});
+        const result = await executeMeetingsTool(
+          (args as Record<string, unknown> & { date: string }) || { date: '' }
+        );
         return {
           content: [result],
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { getTodayMeetingsTool, executeTodayMeetingsTool } from './tools/get-meetings.js';
+import {
+  getTodayMeetingsTool,
+  executeTodayMeetingsTool,
+  getMeetingsTool,
+  executeMeetingsTool,
+} from './tools/get-meetings.js';
 import { config } from 'dotenv';
 
 config();
@@ -31,6 +36,9 @@ class GoogleCalendarMCPServer {
   private registerTools(): void {
     const todayMeetingsTool = getTodayMeetingsTool();
     this.tools.set(todayMeetingsTool.name, todayMeetingsTool);
+
+    const meetingsTool = getMeetingsTool();
+    this.tools.set(meetingsTool.name, meetingsTool);
   }
 
   private setupHandlers(): void {
@@ -47,6 +55,13 @@ class GoogleCalendarMCPServer {
 
       if (name === 'getTodayMeetings') {
         const result = await executeTodayMeetingsTool(args || {});
+        return {
+          content: [result],
+        };
+      }
+
+      if (name === 'getMeetings') {
+        const result = await executeMeetingsTool((args as any) || {});
         return {
           content: [result],
         };

--- a/src/tools/get-meetings.ts
+++ b/src/tools/get-meetings.ts
@@ -244,7 +244,7 @@ export function getTodayMeetingsTool() {
     name: 'getTodayMeetings',
     description: "Get today's meetings from Google Calendar with intelligent filtering",
     inputSchema: {
-      type: 'object',
+      type: 'object' as const,
       properties: {
         timezone: {
           type: 'string',
@@ -283,7 +283,7 @@ export function getMeetingsTool() {
     name: 'getMeetings',
     description: 'Get meetings for a specific date from Google Calendar with intelligent filtering',
     inputSchema: {
-      type: 'object',
+      type: 'object' as const,
       properties: {
         date: {
           type: 'string',

--- a/src/tools/get-meetings.ts
+++ b/src/tools/get-meetings.ts
@@ -169,6 +169,74 @@ export async function getTodayMeetings(params: GetTodayMeetingsParams = {}): Pro
 }
 
 /**
+ * Get meetings for a specific date with filtering
+ */
+export async function getMeetings(
+  date: string,
+  params: GetTodayMeetingsParams = {}
+): Promise<{
+  meetings: MeetingInfo[];
+  timezone: string;
+  date: string;
+}> {
+  const config = getValidatedConfig();
+  const timezone = params.timezone || config.calendar.defaultTimezone;
+
+  try {
+    const client = await getCalendarClient();
+
+    // Parse the date and get start/end of day
+    const targetDate = new Date(date);
+    if (isNaN(targetDate.getTime())) {
+      throw new Error(`Invalid date format: ${date}. Expected format: YYYY-MM-DD`);
+    }
+
+    const startOfDay = new Date(targetDate);
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const endOfDay = new Date(targetDate);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    // Get events for the specified date
+    const events = await client.getAllEvents({
+      timeMin: startOfDay.toISOString(),
+      timeMax: endOfDay.toISOString(),
+      timeZone: timezone,
+      orderBy: 'startTime',
+      singleEvents: true,
+    });
+
+    // Create filter configuration
+    const filterConfig: FilterConfig = {
+      minAttendees: params.minAttendees ?? config.filter.minAttendees,
+      excludeKeywords: params.excludeKeywords ?? config.filter.excludeKeywords,
+      requireAccepted: !params.includeDeclined && config.filter.requireAccepted,
+      excludeDeclined: !params.includeDeclined && config.filter.excludeDeclined,
+      excludeAllDayEvents: config.filter.excludeAllDayEvents,
+    };
+
+    // Apply filters
+    const filter = createMeetingFilter(filterConfig);
+    const filteredEvents = filter.filterEvents(events);
+
+    // Format events to meeting info
+    const meetings = filteredEvents.map(formatEventToMeeting);
+
+    // Sort by start time
+    meetings.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
+
+    return {
+      meetings,
+      timezone,
+      date: targetDate.toISOString().split('T')[0],
+    };
+  } catch (error) {
+    console.error(`Error fetching meetings for ${date}:`, error);
+    throw new Error(`Failed to fetch meetings: ${error}`);
+  }
+}
+
+/**
  * Tool schema definition for MCP
  */
 export function getTodayMeetingsTool() {
@@ -208,6 +276,49 @@ export function getTodayMeetingsTool() {
 }
 
 /**
+ * Tool schema definition for getMeetings
+ */
+export function getMeetingsTool() {
+  return {
+    name: 'getMeetings',
+    description: 'Get meetings for a specific date from Google Calendar with intelligent filtering',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        date: {
+          type: 'string',
+          description: 'Date in YYYY-MM-DD format (e.g., "2025-10-15")',
+        },
+        timezone: {
+          type: 'string',
+          description: 'Timezone for the calendar events (e.g., "America/New_York", "Asia/Tokyo")',
+          default: 'UTC',
+        },
+        includeDeclined: {
+          type: 'boolean',
+          description: 'Include meetings that you have declined',
+          default: false,
+        },
+        minAttendees: {
+          type: 'number',
+          description: 'Minimum number of attendees required for a meeting to be included',
+          default: 2,
+        },
+        excludeKeywords: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+          description: 'Keywords to exclude from meeting titles and descriptions',
+          default: [],
+        },
+      },
+      required: ['date'],
+    },
+  };
+}
+
+/**
  * Execute the getTodayMeetings tool
  */
 interface ToolArgs {
@@ -230,6 +341,47 @@ export async function executeTodayMeetingsTool(args: ToolArgs): Promise<{
     };
 
     const result = await getTodayMeetings(params);
+
+    return {
+      type: 'text',
+      text: JSON.stringify(result, null, 2),
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      type: 'text',
+      text: JSON.stringify(
+        {
+          error: true,
+          message: errorMessage,
+        },
+        null,
+        2
+      ),
+    };
+  }
+}
+
+/**
+ * Execute the getMeetings tool
+ */
+interface GetMeetingsArgs extends ToolArgs {
+  date: string;
+}
+
+export async function executeMeetingsTool(args: GetMeetingsArgs): Promise<{
+  type: string;
+  text: string;
+}> {
+  try {
+    const params: GetTodayMeetingsParams = {
+      timezone: args.timezone,
+      includeDeclined: args.includeDeclined,
+      minAttendees: args.minAttendees,
+      excludeKeywords: args.excludeKeywords,
+    };
+
+    const result = await getMeetings(args.date, params);
 
     return {
       type: 'text',


### PR DESCRIPTION
## Summary
- Add new `getMeetings` tool that allows fetching calendar events for any specified date (YYYY-MM-DD format)
- Extends existing functionality which was limited to today's events only
- Maintains same filtering capabilities (minAttendees, excludeKeywords, includeDeclined, etc.)

## Changes
- **src/tools/get-meetings.ts**:
  - Add `getMeetings()` function to fetch events for a specific date
  - Add `getMeetingsTool()` schema definition with `date` as required parameter
  - Add `executeMeetingsTool()` to handle tool execution
  - Include date validation and error handling

- **src/index.ts**:
  - Register `getMeetings` tool in the MCP server
  - Add handler for `getMeetings` tool calls

## Test plan
- [x] Build passes without errors
- [x] Linter and formatter pass
- [ ] Manual testing with MCP client to verify date-based meeting retrieval works correctly
- [ ] Test with various date formats to ensure proper validation
- [ ] Verify filtering options work as expected

## Related Issues
This implements the ability to retrieve calendar events for any date, not just today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)