### PR TITLE
feat(auth): add reAuthenticate tool for seamless OAuth re-authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@modelcontextprotocol/sdk": "1.18.1",
         "dotenv": "16.4.7",
         "google-auth-library": "9.14.1",
-        "googleapis": "144.0.0"
+        "googleapis": "144.0.0",
+        "open": "^10.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -1584,6 +1585,21 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1812,6 +1828,46 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2827,6 +2883,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2848,6 +2919,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -2873,6 +2962,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3213,6 +3317,24 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -3602,6 +3724,18 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -4783,6 +4917,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@modelcontextprotocol/sdk": "1.18.1",
     "dotenv": "16.4.7",
     "google-auth-library": "9.14.1",
-    "googleapis": "144.0.0"
+    "googleapis": "144.0.0",
+    "open": "^10.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ class GoogleCalendarMCPServer {
     this.server.setRequestHandler(ListPromptsRequestSchema, async () => ({
       prompts: [
         {
-          name: 're-authenticate',
+          name: 'Re-authenticate',
           description: 'Re-authenticate with Google Calendar API',
         },
       ],
@@ -71,14 +71,14 @@ class GoogleCalendarMCPServer {
     this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
       const { name } = request.params;
 
-      if (name === 're-authenticate') {
+      if (name === 'Re-authenticate') {
         return {
           messages: [
             {
               role: 'user',
               content: {
                 type: 'text',
-                text: 'Please execute the reAuthenticate tool to refresh my Google Calendar API credentials.',
+                text: 'Please execute the Re-authenticate tool to refresh my Google Calendar API credentials.',
               },
             },
           ],
@@ -111,7 +111,7 @@ class GoogleCalendarMCPServer {
         };
       }
 
-      if (name === 'reAuthenticate') {
+      if (name === 'Re-authenticate') {
         const result = await executeReAuthenticateTool();
         return {
           content: [result],

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import {
@@ -29,6 +31,7 @@ class GoogleCalendarMCPServer {
       {
         capabilities: {
           tools: {},
+          prompts: {},
         },
       }
     );
@@ -50,9 +53,40 @@ class GoogleCalendarMCPServer {
   }
 
   private setupHandlers(): void {
+    // Tools handlers
     this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
       tools: Array.from(this.tools.values()),
     }));
+
+    // Prompts handlers
+    this.server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+      prompts: [
+        {
+          name: 're-authenticate',
+          description: 'Re-authenticate with Google Calendar API',
+        },
+      ],
+    }));
+
+    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+      const { name } = request.params;
+
+      if (name === 're-authenticate') {
+        return {
+          messages: [
+            {
+              role: 'user',
+              content: {
+                type: 'text',
+                text: 'Please execute the reAuthenticate tool to refresh my Google Calendar API credentials.',
+              },
+            },
+          ],
+        };
+      }
+
+      throw new Error(`Prompt ${name} not found`);
+    });
 
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ import {
   getMeetingsTool,
   executeMeetingsTool,
 } from './tools/get-meetings.js';
+import {
+  reAuthenticateTool,
+  executeReAuthenticateTool,
+} from './tools/re-authenticate.js';
 import { config } from 'dotenv';
 
 config();
@@ -43,6 +47,9 @@ class GoogleCalendarMCPServer {
 
     const meetingsTool = getMeetingsTool();
     this.tools.set(meetingsTool.name, meetingsTool);
+
+    const reAuthTool = reAuthenticateTool();
+    this.tools.set(reAuthTool.name, reAuthTool);
   }
 
   private setupHandlers(): void {
@@ -68,6 +75,13 @@ class GoogleCalendarMCPServer {
         const result = await executeMeetingsTool(
           (args as Record<string, unknown> & { date: string }) || { date: '' }
         );
+        return {
+          content: [result],
+        };
+      }
+
+      if (name === 'reAuthenticate') {
+        const result = await executeReAuthenticateTool();
         return {
           content: [result],
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,7 @@ import {
   getMeetingsTool,
   executeMeetingsTool,
 } from './tools/get-meetings.js';
-import {
-  reAuthenticateTool,
-  executeReAuthenticateTool,
-} from './tools/re-authenticate.js';
+import { reAuthenticateTool, executeReAuthenticateTool } from './tools/re-authenticate.js';
 import { config } from 'dotenv';
 
 config();

--- a/src/tools/re-authenticate.ts
+++ b/src/tools/re-authenticate.ts
@@ -95,9 +95,9 @@ async function reAuthenticate(): Promise<ReAuthenticateResult> {
  */
 export function reAuthenticateTool() {
   return {
-    name: 'reAuthenticate',
+    name: 'Re-authenticate',
     description:
-      'Re-authenticate with Google Calendar API. This will open a browser window for OAuth authentication and save new credentials.',
+      'Re-authenticate with Google Calendar API',
     inputSchema: {
       type: 'object' as const,
       properties: {},

--- a/src/tools/re-authenticate.ts
+++ b/src/tools/re-authenticate.ts
@@ -1,0 +1,137 @@
+import { OAuthManager } from '../auth/oauth.js';
+import { TokenManager } from '../auth/token-manager.js';
+import { getValidatedConfig } from '../config/settings.js';
+import open from 'open';
+
+interface ReAuthenticateResult {
+  success: boolean;
+  message: string;
+  tokenInfo?: {
+    hasRefreshToken: boolean;
+    expiryDate?: number;
+    scopes?: string;
+  };
+}
+
+/**
+ * Re-authenticate with Google Calendar API
+ * This tool will:
+ * 1. Check current token status
+ * 2. Clear existing tokens
+ * 3. Open browser for authentication
+ * 4. Wait for OAuth callback
+ * 5. Save new tokens
+ */
+async function reAuthenticate(): Promise<ReAuthenticateResult> {
+  try {
+    const config = getValidatedConfig();
+
+    const oauthManager = new OAuthManager({
+      clientId: config.google.clientId,
+      clientSecret: config.google.clientSecret,
+      redirectUri: config.google.redirectUri,
+      scopes: config.google.scopes,
+    });
+
+    const tokenManager = new TokenManager(config.storage.tokenPath, oauthManager);
+
+    // Check existing tokens
+    const existingTokens = await tokenManager.loadTokens();
+    if (existingTokens) {
+      console.log('🔍 Found existing tokens. Clearing...');
+      await tokenManager.deleteTokens();
+    }
+
+    // Generate authentication URL
+    const authUrl = oauthManager.getAuthUrl();
+    console.log('🔗 Generated authentication URL');
+
+    // Open browser automatically
+    console.log('🌐 Opening browser for authentication...');
+    await open(authUrl);
+
+    const port = new URL(config.google.redirectUri).port || '3901';
+    console.log(`⏳ Waiting for authorization callback on port ${port}...`);
+
+    // Start OAuth callback server and wait for auth code
+    const authCode = await oauthManager.startAuthServer();
+    console.log('✅ Authorization code received. Exchanging for tokens...');
+
+    // Exchange auth code for tokens
+    const tokens = await oauthManager.getTokensFromCode(authCode);
+    const tokenData = {
+      access_token: tokens.access_token || '',
+      scope: tokens.scope || '',
+      token_type: tokens.token_type || 'Bearer',
+      expiry_date: tokens.expiry_date || Date.now() + 3600 * 1000,
+      refresh_token: tokens.refresh_token || undefined,
+    };
+
+    // Save tokens
+    await tokenManager.saveTokens(tokenData);
+    console.log('💾 Tokens saved successfully');
+
+    return {
+      success: true,
+      message: 'Successfully re-authenticated with Google Calendar API',
+      tokenInfo: {
+        hasRefreshToken: !!tokenData.refresh_token,
+        expiryDate: tokenData.expiry_date,
+        scopes: tokenData.scope,
+      },
+    };
+  } catch (error) {
+    console.error('❌ Re-authentication failed:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      success: false,
+      message: `Re-authentication failed: ${errorMessage}`,
+    };
+  }
+}
+
+/**
+ * Tool schema definition for MCP
+ */
+export function reAuthenticateTool() {
+  return {
+    name: 'reAuthenticate',
+    description:
+      'Re-authenticate with Google Calendar API. This will open a browser window for OAuth authentication and save new credentials.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  };
+}
+
+/**
+ * Execute the reAuthenticate tool
+ */
+export async function executeReAuthenticateTool(): Promise<{
+  type: string;
+  text: string;
+}> {
+  try {
+    const result = await reAuthenticate();
+
+    return {
+      type: 'text',
+      text: JSON.stringify(result, null, 2),
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      type: 'text',
+      text: JSON.stringify(
+        {
+          success: false,
+          message: errorMessage,
+        },
+        null,
+        2
+      ),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new MCP tool `reAuthenticate` that enables users to re-authenticate with Google Calendar API directly through Claude Code without manual intervention. This tool automates the entire OAuth flow by opening the browser and handling the callback server.

## Problem

Google Calendar API tokens expire periodically, requiring users to re-authenticate. Previously, users had to manually:
1. Run the setup script
2. Copy/paste the authentication URL into a browser
3. Complete the OAuth flow
4. Ensure the callback server was running

This manual process was:
- Time-consuming and interrupts workflow
- Error-prone, especially for users unfamiliar with OAuth flows
- Required technical knowledge to execute setup scripts

## Solution

The `reAuthenticate` tool provides a one-command solution that:
1. **Automated Browser Opening**: Uses the `open` package to automatically launch the default browser with the OAuth URL
2. **Callback Server Management**: Starts and stops the OAuth callback server automatically
3. **Token Lifecycle Management**: Clears old tokens, retrieves new ones, and saves them securely
4. **User-Friendly Feedback**: Provides clear console output and structured JSON responses about the authentication status

## Benefits

### For End Users
- **Seamless Experience**: Single command re-authentication without leaving Claude Code
- **No Manual Steps**: Browser opens automatically, no URL copying required
- **Clear Feedback**: Detailed status messages and token information
- **Error Recovery**: Graceful error handling with informative messages

### For Developers
- **Encapsulated Logic**: All re-authentication logic in a single, well-structured tool
- **Reusable Components**: Leverages existing OAuthManager and TokenManager classes
- **Type Safety**: Full TypeScript support with proper types
- **Testable Design**: Clear separation of concerns for easier testing

## Implementation Details

### New Dependencies
- `open` (v10.2.0): Cross-platform package for opening URLs in the default browser

### New Files
- `/src/tools/re-authenticate.ts`: Complete implementation of the reAuthenticate tool
  - `reAuthenticate()`: Core async function handling the re-auth flow
  - `reAuthenticateTool()`: MCP tool schema definition
  - `executeReAuthenticateTool()`: Tool execution wrapper

### Modified Files
- `/src/index.ts`: Registered the new tool in the MCP server
- `package.json` & `package-lock.json`: Added `open` dependency

### Tool Response Format
```json
{
  "success": true,
  "message": "Successfully re-authenticated with Google Calendar API",
  "tokenInfo": {
    "hasRefreshToken": true,
    "expiryDate": 1730000000000,
    "scopes": "https://www.googleapis.com/auth/calendar.readonly"
  }
}
```

## Quality Assurance

All quality checks passed:
- ✅ TypeScript type checking (`npm run typecheck`)
- ✅ Linting (`npm run lint`)
- ✅ Code formatting (`npm run format`)
- ✅ Tests (`npm run test:run`)
- ✅ Build (`npm run build`)

## Usage Example

Users can now re-authenticate simply by asking Claude:
```
"I need to re-authenticate with Google Calendar"
```

Claude Code will automatically call the `reAuthenticate` tool, which:
1. Opens the browser for OAuth consent
2. Handles the callback
3. Saves the new tokens
4. Confirms success with token details

## Future Enhancements

Potential improvements for future PRs:
- Token expiry detection with proactive re-auth prompts
- Support for multiple Google accounts
- Token refresh without full re-authentication when refresh token is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>