### PR TITLE
fix: rename MIN_PARTICIPANTS to MIN_ATTENDEES in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,4 +17,4 @@ LOG_LEVEL=info
 
 # Filtering Configuration
 EXCLUDE_KEYWORDS=lunch,break,personal
-MIN_PARTICIPANTS=2
+MIN_ATTENDEES=2


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency between the example environment variable name and the actual code implementation.

## Changes

- Renamed `MIN_PARTICIPANTS` to `MIN_ATTENDEES` in `.env.example`
- This aligns with the code in `settings.ts` which reads `process.env.MIN_ATTENDEES`

## Motivation

The environment variable name in `.env.example` was inconsistent with what the code actually reads from `process.env`. This could cause configuration errors when users copy the example file and set up their environment.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)